### PR TITLE
Move more functionality here from fontc_crater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ serde_json = "1.0.117"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.10.1"
 ureq = "2.9.7"
-
+font-types = { version = "0.7", features= ["serde"] }
+thiserror = "1.0.37"
+serde_yaml = "0.9.14"

--- a/README.md
+++ b/README.md
@@ -10,4 +10,16 @@ For each repository we find, we then look for a `config.yaml` file in that
 repository's `/source` directory, which is present by convention on sources
 intended to be built by Google Fonts.
 
+# use
+
+To use this tool from the command line, in order to generate a JSON dictionary
+containing information about source repositories:
+
+```sh
+cargo run -- -o repo_list.json
+```
+
+To use this tool from another Rust crate, see [the docs].
+
 [metadata file]: https://github.com/googlefonts/gftools/blob/main/Lib/gftools/fonts_public.proto
+[the docs]: https://docs.rs/google-fonts-sources/

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, clap::Parser)]
 #[command(version, about)]
+#[doc(hidden)] // only intended to be used from our binary
 pub struct Args {
     /// Path to local checkout of google/fonts repository
     #[arg(short, long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,34 @@
+//! parsing google fonts config files
+
+use std::path::Path;
+
+use font_types::Tag;
+
+use crate::error::BadConfig;
+
+/// Google fonts config file ('config.yaml')
+///
+/// This is a standard file that describes the sources and steps for building a
+/// font. See [googlefonts-project-template][template].
+///
+/// [template]: https://github.com/googlefonts/googlefonts-project-template/blob/main/sources/config.yaml
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+// there are a bunch of other fields here we may need to add in the future
+#[non_exhaustive]
+pub struct Config {
+    pub sources: Vec<String>,
+    pub family_name: Option<String>,
+    #[serde(default)]
+    pub build_variable: bool,
+    #[serde(default)]
+    pub axis_order: Vec<Tag>,
+}
+
+impl Config {
+    /// Parse and return a config.yaml file for the provided font source
+    pub fn load(config_path: &Path) -> Result<Self, BadConfig> {
+        let contents = std::fs::read_to_string(config_path)?;
+        serde_yaml::from_str(&contents).map_err(BadConfig::Yaml)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,62 @@ impl<T, E: Display> UnwrapOrDie<T, E> for Result<T, E> {
     }
 }
 
+/// Errors that occur while trying to load a config file
+#[derive(Debug, thiserror::Error)]
+pub enum BadConfig {
+    /// The file could not be read
+    #[error(transparent)]
+    Read(#[from] std::io::Error),
+    /// The yaml could not be parsed
+    #[error(transparent)]
+    Yaml(serde_yaml::Error),
+}
+
+/// Things that go wrong when trying to clone and read a font repo
+#[derive(Debug, thiserror::Error)]
+pub enum LoadRepoError {
+    #[error("could not create local directory: '{0}'")]
+    Io(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
+    #[error("git failed: '{0}'")]
+    GitFail(
+        #[source]
+        #[from]
+        GitFail,
+    ),
+    /// The expected commit could not be found
+    #[error("could not find commit '{sha}'")]
+    NoCommit { sha: String },
+
+    /// No config file was found
+    #[error("no config file was found")]
+    NoConfig,
+    #[error("couldn't load config file: '{0}'")]
+    BadConfig(
+        #[source]
+        #[from]
+        BadConfig,
+    ),
+}
+
+/// Things that go wrong when trying to run a git command
+#[derive(Debug, thiserror::Error)]
+pub enum GitFail {
+    /// The git command itself does not execute
+    #[error("process failed: '{0}'")]
+    ProcessFailed(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
+    /// The git command returns a non-zero status
+    #[error("command failed: '{0}'")]
+    GitError(String),
+}
+
 pub(crate) enum MetadataError {
     Read(std::io::Error),
     Parse(BadMetadata),

--- a/src/repo_info.rs
+++ b/src/repo_info.rs
@@ -1,0 +1,64 @@
+//! font repository information
+
+use std::path::{Path, PathBuf};
+
+use crate::{error::LoadRepoError, Config};
+
+/// Information about a git repository containing font sources
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct RepoInfo {
+    /// The name of the repository.
+    ///
+    /// This is everything after the trailing '/' in e.g. `https://github.com/PaoloBiagini/Joan`
+    pub repo_name: String,
+    /// The repository's url
+    pub repo_url: String,
+    /// The commit rev of the repository's main branch, at discovery time.
+    pub rev: String,
+    /// The names of config files that exist in this repository's source directory
+    pub config_files: Vec<PathBuf>,
+}
+
+impl RepoInfo {
+    /// Return the a `Vec` of source files in this respository.
+    ///
+    /// If necessary, this will create a new checkout of this repo at
+    /// '{font_dir}/{repo_name}'.
+    pub fn get_sources(&self, font_repos_dir: &Path) -> Result<Vec<PathBuf>, LoadRepoError> {
+        let font_dir = font_repos_dir.join(&self.repo_name);
+
+        if !font_dir.exists() {
+            std::fs::create_dir_all(&font_dir)?;
+            super::clone_repo(&self.repo_url, &font_dir)?;
+        }
+
+        if !super::checkout_rev(&font_dir, &self.rev)? {
+            return Err(LoadRepoError::NoCommit {
+                sha: self.rev.clone(),
+            });
+        }
+
+        let source_dir = font_dir.join("sources");
+        let configs = self
+            .config_files
+            .iter()
+            .map(|filename| {
+                let config_path = source_dir.join(filename);
+                Config::load(&config_path)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if configs.is_empty() {
+            return Err(LoadRepoError::NoConfig);
+        }
+
+        let mut sources = configs
+            .iter()
+            .flat_map(|c| c.sources.iter())
+            .map(|source| source_dir.join(source))
+            .collect::<Vec<_>>();
+        sources.sort_unstable();
+        sources.dedup();
+
+        Ok(sources)
+    }
+}


### PR DESCRIPTION
This moves functionality for actually finding sources from config files to this repository, where they can be generally useful.

It also improves docs and the readme a little bit to reflect this.