### PR TITLE
Simplify arguments

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -6,12 +6,11 @@ use std::path::PathBuf;
 #[command(version, about)]
 #[doc(hidden)] // only intended to be used from our binary
 pub struct Args {
-    /// Path to local checkout of google/fonts repository
-    #[arg(short, long)]
-    pub repo_path: Option<PathBuf>,
-    #[arg(short, long)]
-    /// Path to a directory where we should checkout fonts; will reuse existing checkouts
-    pub fonts_dir: Option<PathBuf>,
+    /// Path to a directory where we will store font sources.
+    ///
+    /// This should be a directory dedicated to this task; the tool will
+    /// assume that anything in it can be modified or deleted as needed.
+    pub fonts_dir: PathBuf,
     /// Path to write output. If omitted, output is printed to stdout
     #[arg(short, long)]
     pub out: Option<PathBuf>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 use crate::metadata::BadMetadata;
 
@@ -20,6 +20,17 @@ impl<T, E: Display> UnwrapOrDie<T, E> for Result<T, E> {
             }
         }
     }
+}
+
+/// Errors that occur while trying to find sources
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An io error occurred
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// an error with reading the google/fonts repo
+    #[error(transparent)]
+    Git(#[from] GitFail),
 }
 
 /// Errors that occur while trying to load a config file
@@ -74,8 +85,8 @@ pub enum GitFail {
         std::io::Error,
     ),
     /// The git command returns a non-zero status
-    #[error("command failed: '{0}'")]
-    GitError(String),
+    #[error("command failed: in '{path}': '{stderr}'")]
+    GitError { path: PathBuf, stderr: String },
 }
 
 pub(crate) enum MetadataError {


### PR DESCRIPTION
- remove separate flag for google/fonts path; we will just always check it out in the main cache dir
- make the main cache dir required; if a consumer wants a tempdir they can create it and pass it in.
- remove the verbose flag