### PR TITLE
Support private repositories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-fonts-sources"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "finding source repositories of Google Fonts fonts"
 license = "MIT/Apache-2.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,8 @@ pub enum LoadRepoError {
         #[from]
         BadConfig,
     ),
+    #[error("reposity requires an auth token but GITHUB_TOKEN not set")]
+    MissingAuth,
 }
 
 /// Things that go wrong when trying to run a git command


### PR DESCRIPTION
All private repositories must be accessible via a single OAuth token, and can only be specified manually in JSON (we will not automatically discover these repositories.)

This will let us support brand fonts in crater.