### PR TITLE
Don't serialize 'auth' field if it's false

### DIFF
--- a/src/repo_info.rs
+++ b/src/repo_info.rs
@@ -26,8 +26,13 @@ pub struct RepoInfo {
     /// We don't discover these repos, but they can be specified in json and
     /// we will load them. In this case, a valid oauth token must be specified
     /// via the `GITHUB_TOKEN` environment variable.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     auth: bool,
+}
+
+// a little helper used above
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl RepoInfo {


### PR DESCRIPTION
Since this is almost always the case.

In practice we don't expect to be serializing this even if true (since at least currently its only 'true' if it is specified manually) but we might as well be defensive in case we are doing something fancier in the future.