### PR TITLE
Always store full git rev

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,8 +454,7 @@ fn get_git_rev_remote(repo_url: &str) -> Result<GitRev, ConfigFetchIssue> {
 /// a git repository)
 fn get_git_rev(repo_path: &Path) -> Result<String, GitFail> {
     let mut cmd = std::process::Command::new("git");
-    cmd.args(["rev-parse", "--short", "HEAD"])
-        .current_dir(repo_path);
+    cmd.args(["rev-parse", "HEAD"]).current_dir(repo_path);
     let output = cmd.output()?;
 
     if !output.status.success() {


### PR DESCRIPTION
This is a simplification, since we can't get short revs for sources discovered over http (versus by local checkout)

- partly addresses #30 