### PR TITLE
Do normal git fetch after --unshallow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,12 @@ fn checkout_rev(repo_dir: &Path, rev: &str) -> Result<bool, GitFail> {
         .args(["fetch", "--unshallow"])
         .output();
 
+    // but if they're _not_ shallow, we need normal fetch :/
+    let _ = std::process::Command::new("git")
+        .current_dir(repo_dir)
+        .args(["fetch"])
+        .output();
+
     let result = std::process::Command::new("git")
         .current_dir(repo_dir)
         .arg("checkout")


### PR DESCRIPTION
Because --unshallow doesn't do anything if the repo isn't shallow (I assumed it would do a normal fetch, in this case)