### PR TITLE
Report missing `sources/config.yaml`

### DIFF
--- a/src/repo_info.rs
+++ b/src/repo_info.rs
@@ -139,7 +139,7 @@ impl RepoInfo {
         cache_dir: &Path,
     ) -> Result<impl Iterator<Item = PathBuf> + '_, LoadRepoError> {
         let font_dir = self.instantiate(cache_dir)?;
-        let (left, right) = match super::iter_config_paths(&font_dir) {
+        let (left, right) = match super::iter_config_paths(&font_dir, "Local checkout") {
             Ok(iter) => (Some(iter), None),
             Err(_) => (None, None),
         };


### PR DESCRIPTION
When a repo is found, but it lacks the sources/config.yaml file, then we want to report the URL so that someone can further inspect it (and hopefully add the missing file)

(co-authored by @felipesanches and @simoncozens)