### PR TITLE
Preliminary support for virtual configs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-fonts-sources"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "finding source repositories of Google Fonts fonts"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This supports the idea that a config can live outside of the repo, which is the case for a few particular fonts where we cannot or do not want to modify the upstream repo.